### PR TITLE
Fix Unicode width handling and improve layout space utilization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,12 +72,12 @@ mod state_parser;
 mod types;
 
 pub use error::MermaidError;
+pub use layout::{compute_layout, compute_layout_with_options};
 pub use types::{
     Direction, Edge, EdgeStyle, Graph, Node, NodeId, NodeShape, RenderOptions, Subgraph,
 };
 
 use d2_parser::parse_d2;
-use layout::compute_layout;
 use parser::parse_mermaid;
 use pie_parser::{parse_pie_chart as parse_pie, render_pie_chart as render_pie};
 use renderer::render_graph;
@@ -162,7 +162,7 @@ pub fn render_diagram(input: &str, options: RenderOptions) -> Result<String, Mer
 /// * `Err(MermaidError)` - Parse or layout error
 pub fn render_mermaid_to_tui(input: &str, options: RenderOptions) -> Result<String, MermaidError> {
     let mut graph = parse_mermaid(input)?;
-    compute_layout(&mut graph);
+    compute_layout_with_options(&mut graph, &options);
     Ok(render_graph(&graph, &options))
 }
 
@@ -177,7 +177,7 @@ pub fn render_mermaid_to_tui(input: &str, options: RenderOptions) -> Result<Stri
 /// * `Err(MermaidError)` - Parse or layout error
 pub fn render_state_diagram(input: &str, options: RenderOptions) -> Result<String, MermaidError> {
     let mut graph = parse_state_diagram(input)?;
-    compute_layout(&mut graph);
+    compute_layout_with_options(&mut graph, &options);
     Ok(render_graph(&graph, &options))
 }
 
@@ -208,7 +208,7 @@ pub fn render_pie_chart(input: &str, options: RenderOptions) -> Result<String, M
 /// * `Err(MermaidError)` - Parse or layout error
 pub fn render_d2_to_tui(input: &str, options: RenderOptions) -> Result<String, MermaidError> {
     let mut graph = parse_d2(input)?;
-    compute_layout(&mut graph);
+    compute_layout_with_options(&mut graph, &options);
     Ok(render_graph(&graph, &options))
 }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -124,11 +124,13 @@ pub fn render_graph(graph: &Graph, options: &RenderOptions) -> String {
     let output = grid.to_string();
 
     // Apply max_width constraint if set
+    // Use chars().count() for visual width, not len() which counts bytes
     if let Some(max_width) = options.max_width {
         output
             .lines()
             .map(|line| {
-                if line.len() > max_width {
+                let char_count = line.chars().count();
+                if char_count > max_width {
                     // Truncate and add ellipsis indicator
                     let mut truncated: String =
                         line.chars().take(max_width.saturating_sub(1)).collect();


### PR DESCRIPTION
## Summary
- Fix truncation using `chars().count()` instead of `len()` (byte count)
- Add `compute_layout_with_options()` that considers `max_width`
- Dynamically adjust horizontal gaps when diagram is too wide
- Use `chars().count()` for node width calculation

## Problem
When rendering diagrams with Unicode box-drawing characters, the truncation logic was comparing byte length against max_width. Since Unicode characters like `┌`, `─`, `┐` are 3 bytes each but only 1 visual character, this caused incorrect truncation.

## Solution
1. Fixed truncation to use character count instead of byte length
2. Added `compute_layout_with_options()` that accepts `RenderOptions`
3. When `max_width` is set and the diagram is too wide, gaps are dynamically reduced

## Test plan
- [x] All 126 tests pass
- [x] No clippy warnings