### PR TITLE
Expose supported languages list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,19 @@ use renderer::render_graph;
 use seq_parser::{parse_sequence_diagram as parse_seq, render_sequence_diagram as render_seq};
 use state_parser::parse_state_diagram;
 
+/// Languages supported by graphs-tui.
+///
+/// Callers can use this instead of maintaining their own hardcoded lists.
+pub const SUPPORTED_LANGUAGES: &[&str] = &["mermaid", "d2"];
+
+/// Check if a language string is supported for rendering.
+///
+/// Matches `SUPPORTED_LANGUAGES` entries case-insensitively.
+pub fn is_supported(lang: &str) -> bool {
+    let lower = lang.to_lowercase();
+    SUPPORTED_LANGUAGES.iter().any(|&l| l == lower)
+}
+
 /// Diagram format
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiagramFormat {

--- a/tests/issue_tests.rs
+++ b/tests/issue_tests.rs
@@ -1,5 +1,8 @@
 //! Tests for GitHub issues
-use graphs_tui::{render_d2_to_tui, render_mermaid_to_tui, DiagramWarning, RenderOptions};
+use graphs_tui::{
+    is_supported, render_d2_to_tui, render_mermaid_to_tui, DiagramWarning, RenderOptions,
+    SUPPORTED_LANGUAGES,
+};
 
 /// Issue #7: Warnings returned in RenderResult instead of eprintln
 #[test]
@@ -287,4 +290,24 @@ fn test_issue_9_no_legend_when_labels_fit() {
         "No legend when labels fit inline"
     );
     assert!(result.output.contains("yes"), "Label should appear inline");
+}
+
+// ── Issue #12: Expose supported languages list ───────────────────────
+
+/// Issue #12: SUPPORTED_LANGUAGES contains mermaid and d2
+#[test]
+fn test_issue_12_supported_languages() {
+    assert!(SUPPORTED_LANGUAGES.contains(&"mermaid"));
+    assert!(SUPPORTED_LANGUAGES.contains(&"d2"));
+}
+
+/// Issue #12: is_supported works case-insensitively
+#[test]
+fn test_issue_12_is_supported() {
+    assert!(is_supported("mermaid"));
+    assert!(is_supported("Mermaid"));
+    assert!(is_supported("D2"));
+    assert!(is_supported("d2"));
+    assert!(!is_supported("graphviz"));
+    assert!(!is_supported(""));
 }


### PR DESCRIPTION
## Summary
Closes #12

- Add `SUPPORTED_LANGUAGES: &[&str]` const (`["mermaid", "d2"]`)
- Add `is_supported(lang: &str) -> bool` with case-insensitive matching

## Test plan
- [x] `SUPPORTED_LANGUAGES` contains mermaid and d2
- [x] `is_supported` works case-insensitively, rejects unknown languages