### PR TITLE
Pin winnow >= 0.6.26 (ModalResult added in 0.6.26)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 unicode-width = "0.2"
-winnow = "0.6"
+winnow = "0.6.26"
 
 [dev-dependencies]
 insta = "1.40"


### PR DESCRIPTION
## Summary
- `ModalResult` was added in winnow 0.6.26, but Cargo.toml specified `"0.6"` allowing older versions
- Fix: one-line pin `winnow = "0.6.26"`

Fixes #29

## Test plan
- `rm Cargo.lock && cargo test` — all 218 tests pass